### PR TITLE
avoid an error on click

### DIFF
--- a/src/components/Switch.svelte
+++ b/src/components/Switch.svelte
@@ -169,7 +169,7 @@
 
   function onClick(event) {
     event.preventDefault();
-    inputRef.focus();
+    inputRef && inputRef.focus && inputRef.focus();
     onChangeTrigger(event);
     state.hasOutline = false;
   }


### PR DESCRIPTION
Sometimes my console shows this message when the component is clicked:

```
Uncaught TypeError: inputRef is null
```

This should fix the error :)